### PR TITLE
Fix error with pinned tabs

### DIFF
--- a/src/pages/Background/index.js
+++ b/src/pages/Background/index.js
@@ -223,7 +223,7 @@ const alignTabs = async (windowId) => {
         const orderedRules = rules.sort((a, b) => a.key - b.key);
         const currentTabGroups = await new Promise(resolve => chrome.tabGroups.query({ windowId }, resolve))
         const tabs = await new Promise(resolve => chrome.tabs.query({ windowId }, resolve))
-        let offset = 0;
+        let offset = tabs.filter(t => t.pinned).length;
         for (const r of orderedRules) {
             const groupId = await getGroupIdForRule(windowId, r);
             const tabsInGroup = tabs.filter(t => t.groupId === groupId);


### PR DESCRIPTION
If you have a pinned tab, the service worker sometimes displays an error in the console, and tabs seem to jump around unexpectedly.

The error logged is:
```
background.bundle.js:1 Cannot move the group to an index that is in the middle of pinned tabs.
```

Misplaced tabs:
![image](https://user-images.githubusercontent.com/277403/128615753-af7ec5cf-7a24-4edc-bf7d-aa6dd10883d7.png)
The YouTube tabs are in the same group, and Facebook is in another group. 

After some experimentation, I found that pinned tabs always are at the beginning of the list, and are marked with the property `pinned: true`. The easiest fix was to start counting after the pinned tabs.

The pinned tabs and groups are mutually exclusive. The only overlap would be if a pinned tab is on a domain that would normally be part an AcidTabs group. That case is handled in another method, where the tab is added to a group, which automatically unpins it.

If I switch to my updated version, the tabs are immediately fixed:
![image](https://user-images.githubusercontent.com/277403/128615967-7c427900-5034-4357-9839-29dead59c286.png)